### PR TITLE
ReportScreen fix filtering dummy Yields

### DIFF
--- a/RH_AI.modinfo
+++ b/RH_AI.modinfo
@@ -854,6 +854,15 @@
 			</Properties>
 		</ReplaceUIScript>
 
+		<!-- ReportScreen fixes -->
+		<ReplaceUIScript id="ReplaceUI_ReportScreen">
+			<Properties>
+				<LoadOrder>10950</LoadOrder>
+				<LuaContext>ReportScreen</LuaContext>
+				<LuaReplace>core/UI/ReportScreenWrapper.lua</LuaReplace>
+			</Properties>
+		</ReplaceUIScript>
+
 
 		<!-- Text -->
 
@@ -1029,6 +1038,9 @@
 
 		<File>core/UI/ToolTipHelper.lua</File>
 		<File>core/UI/ToolTip_Adjust.lua</File>
+
+		<!-- ReportScreen -->
+		<File>core/UI/ReportScreenWrapper.lua</File>
 
 		<!-- Community Extension Support -->
 		<File>core/Strategies/Community_Extension/Scripts/CongressAI.lua</File>

--- a/core/UI/ReportScreenWrapper.lua
+++ b/core/UI/ReportScreenWrapper.lua
@@ -1,0 +1,38 @@
+include('ReportScreen')
+rhai_tags = GameInfo.RHAITags
+function GetWorkedTileYieldData( pCity, pCulture )
+
+	-- Loop through all the plots for a given city; tallying the resource amount.
+	local kYields  = {
+		YIELD_PRODUCTION= 0,
+		YIELD_FOOD		= 0,
+		YIELD_GOLD		= 0,
+		YIELD_FAITH		= 0,
+		YIELD_SCIENCE	= 0,
+		YIELD_CULTURE	= 0,
+		TOURISM			= 0,
+	};
+	local cityPlots  = Map.GetCityPlots():GetPurchasedPlots(pCity);
+	local pCitizens	 = pCity:GetCitizens();
+	print('Getting plot worked yields')
+	for _, plotID in ipairs(cityPlots) do
+		local plot	 = Map.GetPlotByIndex(plotID);
+		local x		 = plot:GetX();
+		local y		 = plot:GetY();
+		isPlotWorked = pCitizens:IsPlotWorked(x,y);
+		if isPlotWorked then
+			for row in GameInfo.Yields() do
+				if not rhai_tags[row.Name] then
+					kYields[row.YieldType] = kYields[row.YieldType] + plot:GetYield(row.Index);
+				end
+			end
+		end
+
+		-- Support tourism.
+		-- Not a common yield, and only exposure from game core is based off
+		-- of the plot so the sum is easily shown, but it's not possible to
+		-- show how individual buildings contribute... yet.
+		kYields["TOURISM"] = kYields["TOURISM"] + pCulture:GetTourismAt( plotID );
+	end
+	return kYields;
+end


### PR DESCRIPTION
The ReportScreen uses the Yields table to display stuff. Since RHAI adds a bunch of yields it was breaking. Now it excludes RHAI yields. Compatible with Better Report Screen.