### PR TITLE
ReportScreen Hotfix

### DIFF
--- a/RH_AI.modinfo
+++ b/RH_AI.modinfo
@@ -801,7 +801,7 @@
 
 			<File>core/UI/ToolTipHelper.lua</File>
 			<File>core/UI/CivilopediaPage_District.lua</File>
-			<File>core/UI/TechTree_support.lua</File>
+			<File>core/UI/ReportScreenSupport.lua</File>
 	  	</ImportFiles>
 
 		<ReplaceUIScript id="ResearchChooserHide">
@@ -859,7 +859,23 @@
 			<Properties>
 				<LoadOrder>10950</LoadOrder>
 				<LuaContext>ReportScreen</LuaContext>
-				<LuaReplace>core/UI/ReportScreenWrapper.lua</LuaReplace>
+				<LuaReplace>core/UI/ReportScreen_overrides.lua</LuaReplace>
+			</Properties>
+		</ReplaceUIScript>
+
+		<ReplaceUIScript id="ReplaceUI_ReportScreen" criteria="Expansion1">
+			<Properties>
+				<LoadOrder>10950</LoadOrder>
+				<LuaContext>ReportScreen</LuaContext>
+				<LuaReplace>core/UI/ReportScreen_overrides_XP1.lua</LuaReplace>
+			</Properties>
+		</ReplaceUIScript>
+
+		<ReplaceUIScript id="ReplaceUI_ReportScreen" criteria="Expansion2">
+			<Properties>
+				<LoadOrder>10950</LoadOrder>
+				<LuaContext>ReportScreen</LuaContext>
+				<LuaReplace>core/UI/ReportScreen_overrides_XP2.lua</LuaReplace>
 			</Properties>
 		</ReplaceUIScript>
 
@@ -1040,7 +1056,10 @@
 		<File>core/UI/ToolTip_Adjust.lua</File>
 
 		<!-- ReportScreen -->
-		<File>core/UI/ReportScreenWrapper.lua</File>
+		<File>core/UI/ReportScreenSupport.lua</File>
+		<File>core/UI/ReportScreen_overrides.lua</File>
+		<File>core/UI/ReportScreen_overrides_XP1.lua</File>
+		<File>core/UI/ReportScreen_overrides_XP2.lua</File>
 
 		<!-- Community Extension Support -->
 		<File>core/Strategies/Community_Extension/Scripts/CongressAI.lua</File>

--- a/core/UI/ReportScreenSupport.lua
+++ b/core/UI/ReportScreenSupport.lua
@@ -1,4 +1,3 @@
-include('ReportScreen')
 rhai_tags = GameInfo.RHAITags
 function GetWorkedTileYieldData( pCity, pCulture )
 
@@ -14,7 +13,6 @@ function GetWorkedTileYieldData( pCity, pCulture )
 	};
 	local cityPlots  = Map.GetCityPlots():GetPurchasedPlots(pCity);
 	local pCitizens	 = pCity:GetCitizens();
-	print('Getting plot worked yields')
 	for _, plotID in ipairs(cityPlots) do
 		local plot	 = Map.GetPlotByIndex(plotID);
 		local x		 = plot:GetX();

--- a/core/UI/ReportScreen_overrides.lua
+++ b/core/UI/ReportScreen_overrides.lua
@@ -1,0 +1,3 @@
+include('ReportScreen')
+
+include('ReportScreenSupport.lua')

--- a/core/UI/ReportScreen_overrides_XP1.lua
+++ b/core/UI/ReportScreen_overrides_XP1.lua
@@ -1,0 +1,3 @@
+include('ReportScreen')
+include('ReportScreen_Expansion1.lua')
+include('ReportScreenSupport.lua')

--- a/core/UI/ReportScreen_overrides_XP2.lua
+++ b/core/UI/ReportScreen_overrides_XP2.lua
@@ -1,0 +1,4 @@
+include('ReportScreen')
+include('ReportScreen_Expansion1.lua')
+include('ReportScreen_Expansion2.lua')
+include('ReportScreenSupport.lua')


### PR DESCRIPTION
The ReportScreen change was causing failures as it wasnt taking into account Rise and Fall and GS overrides. Absorbed those with criteria.