### PR TITLE
puts back techtree support file that was accidentally deleted

### DIFF
--- a/RH_AI.modinfo
+++ b/RH_AI.modinfo
@@ -875,6 +875,7 @@
 			<File>core/UI/ToolTipHelper.lua</File>
 			<File>core/UI/CivilopediaPage_District.lua</File>
 			<File>core/UI/ReportScreenSupport.lua</File>
+			<File>core/UI/TechTree_support.lua</File>
 	  	</ImportFiles>
 
 		<ReplaceUIScript id="ResearchChooserHide">


### PR DESCRIPTION
When doing the report screen hotfix, a file reference was deleted. brings it back